### PR TITLE
Redirect authenticated users from homepage to dashboard

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,13 @@
 import Image from "next/image";
+import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
 
-export default function Home() {
+export default async function Home() {
+  const { userId } = await auth();
+
+  if (userId) {
+    redirect("/dashboard");
+  }
   return (
     <div className="flex min-h-screen items-center justify-center bg-zinc-50 font-sans dark:bg-black">
       <main className="flex min-h-screen w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">


### PR DESCRIPTION
When a logged-in user visits the homepage (/), they are now automatically redirected to /dashboard. This improves UX by taking authenticated users directly to the main application interface.

- Added auth() check in homepage Server Component
- Implemented redirect() to /dashboard for authenticated users
- Follows Clerk authentication and Next.js routing standards

Fixes #4