### PR TITLE
fix: protect dashboard routes and add sign-in/sign-up pages

### DIFF
--- a/src/app/sign-in/page.tsx
+++ b/src/app/sign-in/page.tsx
@@ -1,0 +1,9 @@
+import { SignIn } from "@clerk/nextjs";
+
+export default function SignInPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <SignIn />
+    </div>
+  );
+}

--- a/src/app/sign-up/page.tsx
+++ b/src/app/sign-up/page.tsx
@@ -1,0 +1,9 @@
+import { SignUp } from "@clerk/nextjs";
+
+export default function SignUpPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <SignUp />
+    </div>
+  );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,12 @@
-import { clerkMiddleware } from "@clerk/nextjs/server";
+import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 
-export default clerkMiddleware();
+const isPublicRoute = createRouteMatcher(["/", "/sign-in(.*)", "/sign-up(.*)"]);
+
+export default clerkMiddleware(async (auth, request) => {
+  if (!isPublicRoute(request)) {
+    await auth.protect();
+  }
+});
 
 export const config = {
   matcher: [


### PR DESCRIPTION
Fixes #6

## Summary
Fixed the Application Error that occurred when accessing `/dashboard` while logged out.

## Changes
- Updated middleware to properly protect routes using `createRouteMatcher` and `auth.protect()`
- Created `/sign-in` page with Clerk's SignIn component
- Created `/sign-up` page with Clerk's SignUp component

## Testing
To test:
1. Try accessing `/dashboard` while logged out - should redirect to `/sign-in`
2. Sign in page should display Clerk's authentication form
3. After signing in, should be able to access `/dashboard`

Generated with [Claude Code](https://claude.ai/code)